### PR TITLE
Add support for filtering in Sidekiq Pro

### DIFF
--- a/lib/sidekiq/history.rb
+++ b/lib/sidekiq/history.rb
@@ -26,7 +26,7 @@ module Sidekiq
     end
 
     def self.count
-      Sidekiq.redis { |r| r.llen(LIST_KEY) }
+      Sidekiq.redis { |r| r.zcard(LIST_KEY) }
     end
 
     class HistorySet < Sidekiq::JobSet

--- a/lib/sidekiq/history.rb
+++ b/lib/sidekiq/history.rb
@@ -28,7 +28,15 @@ module Sidekiq
     def self.count
       Sidekiq.redis { |r| r.llen(LIST_KEY) }
     end
+
+    class HistorySet < Sidekiq::JobSet
+      def initialize
+        super LIST_KEY
+      end
+    end
+
   end
+
 end
 
 Sidekiq.configure_server do |config|

--- a/lib/sidekiq/history/middleware.rb
+++ b/lib/sidekiq/history/middleware.rb
@@ -19,9 +19,9 @@ module Sidekiq
         }
 
         Sidekiq.redis do |conn|
-          conn.lpush(LIST_KEY, Sidekiq.dump_json(data))
+          conn.zadd(LIST_KEY, data[:started_at].to_f, Sidekiq.dump_json(data))
           unless Sidekiq.history_max_count == false
-            conn.ltrim(LIST_KEY, 0, Sidekiq.history_max_count - 1)
+            conn.zremrangebyrank(LIST_KEY, 0, -(Sidekiq.history_max_count + 1))
           end
         end
 

--- a/lib/sidekiq/history/middleware.rb
+++ b/lib/sidekiq/history/middleware.rb
@@ -19,6 +19,18 @@ module Sidekiq
         }
 
         Sidekiq.redis do |conn|
+          # migration of list to set for backwards compatibility after v0.0.4
+          if conn.type(LIST_KEY) == 'list'
+            length = conn.llen(LIST_KEY)
+            list = conn.lrange(LIST_KEY, 0, length)
+            conn.del(LIST_KEY)
+            list.each do |entry|
+              migrated_data = JSON.parse(entry)
+              conn.zadd(LIST_KEY, data[:started_at].to_f, Sidekiq.dump_json(migrated_data))
+            end
+          end
+
+          # regular storage of history
           conn.zadd(LIST_KEY, data[:started_at].to_f, Sidekiq.dump_json(data))
           unless Sidekiq.history_max_count == false
             conn.zremrangebyrank(LIST_KEY, 0, -(Sidekiq.history_max_count + 1))

--- a/lib/sidekiq/history/web_extension.rb
+++ b/lib/sidekiq/history/web_extension.rb
@@ -12,9 +12,23 @@ module Sidekiq
           render(:erb, File.read("#{ROOT}/views/history.erb"))
         end
 
-        app.post "/history/remove" do
+        app.post '/history/remove' do
           Sidekiq::History.reset_history(counter: params['counter'])
           redirect("#{root_path}history")
+        end
+
+        app.get '/filter/history' do
+          return redirect "#{root_path}history" unless params[:substr]
+
+          @messages = search(HistorySet.new, params[:substr])
+          render(:erb, File.read("#{ROOT}/views/history.erb"))
+        end
+
+        app.post '/filter/history' do
+          return redirect "#{root_path}history" unless params[:substr]
+
+          @messages = search(HistorySet.new, params[:substr])
+          render(:erb, File.read("#{ROOT}/views/history.erb"))
         end
 
         app.settings.locales << File.expand_path('locales', ROOT)

--- a/web/views/history.erb
+++ b/web/views/history.erb
@@ -7,6 +7,7 @@
       <%= erb :_paging, :locals => { :url => "#{root_path}history" } %>
     </div>
   <% end %>
+  <%= filtering('history') %>
 </header>
 
 <% if @messages.size > 0 %>


### PR DESCRIPTION
@russ 

![](http://g.recordit.co/NxWlKM5kSQ.gif)

I added filtering support (a [feature](https://github.com/mperham/sidekiq/wiki/UI-Filtering) only available in Sidekiq Pro).

Data needs to be stored as a redis SET to be searched.
I have added a check to migrate any existing LIST type data to a SET when the middleware is run to provide backwards compatibility.
