### PR TITLE
Add csrf_tag to clear form

### DIFF
--- a/web/views/history.erb
+++ b/web/views/history.erb
@@ -40,6 +40,7 @@
   <div class="row">
     <div class="col-sm-5">
       <form class="form-inline" action="<%= "#{root_path}history/remove" %>" method="post" style="margin: 20px 0">
+        <%= csrf_tag if respond_to?(:csrf_tag) %>
         <input class="btn btn-danger btn-xs" type="submit" name="delete" value="Clear All" />
         <label class="checkbox">
           <input type="checkbox" name="counter" value="true" />


### PR DESCRIPTION
CSRF is required as of sidekiq 3.4.2
https://github.com/mperham/sidekiq/blob/master/Changes.md#342

Without it you'll get a Forbidden error when you click “Clear All” button.

See https://github.com/mperham/sidekiq/issues/1289 for details
