### PR TITLE
Added support for job unwrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Or install it yourself as:
 
 Nothing left to do. Mount sidekiq, and go to the web interface. You'll see a shiny new History tab!
 
-By default it will keep history on the last 1000 jobs.  To change that set `Sidekiq::History::Middleware::MAX_COUNT = 10000`.  Be careful because the data is persisted in Redis Sorted Set and it WILL take up RAM.  Max possible value is 4294967295 per Redis limit.
+By default it will keep history on the last 1000 jobs.  To change that set `Sidekiq.history_max_count = 10000`.  Be careful because the data is persisted in Redis Sorted Set and it WILL take up RAM.  Max possible value is 4294967295 per Redis limit.
 
-If you want to only record history for specific jobs you can set `Sidekiq::History::Middleware::EXCLUDE_JOBS = ['OneJob']` (do not record for specified jobs) and `Sidekiq::History::Middleware::INCLUDE_JOBS = ['AnotherJob']` (record ONLY jobs specified).  INCLUDE will take precedence so if you set it to blank array nothing will be recorded.
+If you want to only record history for specific jobs you can set `Sidekiq.history_exclude_jobs = ['OneJob']` (do not record for specified jobs) and `Sidekiq.history_include_jobs = ['AnotherJob']` (record ONLY jobs specified).  INCLUDE will take precedence so if you set it to blank array nothing will be recorded.
 
 ## Screenshot
 

--- a/lib/sidekiq/history/version.rb
+++ b/lib/sidekiq/history/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module History
-    VERSION = "0.0.9"
+    VERSION = '0.0.9'.freeze
   end
 end

--- a/lib/sidekiq/history/web_extension.rb
+++ b/lib/sidekiq/history/web_extension.rb
@@ -1,7 +1,7 @@
 module Sidekiq
   module History
     module WebExtension
-      ROOT = File.expand_path('../../../../web', __FILE__)
+      ROOT = File.expand_path('../../../web', __dir__)
 
       def self.registered(app)
         app.get '/history' do

--- a/web/views/history.erb
+++ b/web/views/history.erb
@@ -24,7 +24,9 @@
         <td>
           <%= relative_time(Time.parse(entry['started_at'])) %>
         </td>
-        <td><%= entry.queue %></td>
+        <td>
+          <a href="<%= root_path %>queues/<%= entry.queue %>"><%= entry.queue %></a>
+        </td>
         <td>
           <%= entry['payload']['class'] %>
         </td>


### PR DESCRIPTION
First things first: Thank you very much for this great gem!

--

**- What is it good for**

The current documentation is wrong when it comes to the max history count settings and the job inclusion/exclusion does not work like expected on wrapped ActiveJobs. Furthermore the web view is cluttered with the job wrapping stuff. Here comes an example:

![img-2018-09-26-181010](https://user-images.githubusercontent.com/2496275/46096153-b4703680-c1be-11e8-9b14-46abf6feab62.png)

This PR improves the documentation and adds an uniform looking configration style. (`Sidekiq.history_max_count = 3`, `Sidekiq.history_exclude_jobs = ['OneJob']`) The middleware now takes care of unwrapping the bare job payload and view was improved to also link to the queues page.

Here comes an example history with this PR:
![img-2018-09-26-185732](https://user-images.githubusercontent.com/2496275/46096292-1df04500-c1bf-11e8-8f08-93768cd0a7cc.png)

**- What I did**

* Ran rubocop -a over all files (boy scout rule, hope this doesn't hurt)
* Added setters and getters for include/exclude jobs
* Added Sidekiq::Job unwrapping (See [the source](https://github.com/mperham/sidekiq/blob/v5.2.2/lib/sidekiq/api.rb#L340))

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://user-images.githubusercontent.com/2496275/46096527-b8e91f00-c1bf-11e8-8724-c8cbcbc678c2.jpeg)

