### PR TITLE
Added support for sidekiq >= 6.2.2.

### DIFF
--- a/lib/sidekiq/history/middleware.rb
+++ b/lib/sidekiq/history/middleware.rb
@@ -11,7 +11,7 @@ module Sidekiq
         self.msg = msg
 
         # Use the Sidekiq API to unwrap the job
-        job = Sidekiq::Job.new(msg)
+        job = sidekiq_job_class.new(msg)
         job_class = job.display_class
 
         # Setup a unwraped copy of the bare job data
@@ -67,6 +67,19 @@ module Sidekiq
         end
 
         true
+      end
+
+      def sidekiq_job_class
+        @sidekiq_job_class ||= begin
+          actual = Gem.loaded_specs['sidekiq'].version
+          if Gem::Dependency.new('', '>= 6.2.2').match?('', actual)
+            # Renamed internal API class Sidekiq::Job to Sidekiq::JobRecord,
+            # since 6.2.2. See: https://bit.ly/3gtxViK
+            Sidekiq::JobRecord
+          else
+            Sidekiq::Job
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**- What is it good for**

Since Sidekiq 6.2.2 the gem just does not work anymore and cause errors when running jobs like this:

```
sidekiq_1  | 2021-08-24T11:27:48.376Z pid=13 tid=gp6ypuwu5 WARN: ArgumentError: wrong number of arguments (given 1, expected 0)
sidekiq_1  | 2021-08-24T11:27:48.376Z pid=13 tid=gp6ypuwu5 WARN: /usr/local/bundle/gems/sidekiq-history-0.0.11/lib/sidekiq/history/middleware.rb:14:in `initialize'
sidekiq_1  | /usr/local/bundle/gems/sidekiq-history-0.0.11/lib/sidekiq/history/middleware.rb:14:in `new'
sidekiq_1  | /usr/local/bundle/gems/sidekiq-history-0.0.11/lib/sidekiq/history/middleware.rb:14:in `call'
sidekiq_1  | /usr/local/bundle/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
```

The root cause for this is https://github.com/mperham/sidekiq/blob/master/Changes.md#622:
> Rename internal API class Sidekiq::Job to Sidekiq::JobRecord [#4955]

This PR ships a fix for newer Sidekiq versions (>= 6.2.2) while also supporting the older versions.

**- What I did**

I added a new method to the middleware to detect the Sidekiq version and return the correct class for job unwrapping. 
The result of this method is memoized in order to keep the middleware as fast as possible.

**- A picture of a cute animal (not mandatory but encouraged)**

![download](https://user-images.githubusercontent.com/2496275/130611305-b00bcd5a-ee53-4b6b-92f1-45bbd9505ae8.jpeg)
