### PR TITLE
Add Sidekiq 8 compatibility

### DIFF
--- a/lib/sidekiq/history.rb
+++ b/lib/sidekiq/history.rb
@@ -74,11 +74,22 @@ Sidekiq.configure_server do |config|
   end
 end
 
-Sidekiq::Web.register(Sidekiq::History::WebExtension)
-
-if Sidekiq::Web.tabs.is_a?(Array)
-  # For sidekiq < 2.5
-  Sidekiq::Web.tabs << 'history'
+# for Sidekiq >= 8.0.0
+if Gem::Dependency.new('', '>= 8.0.0').match?('', Gem.loaded_specs['sidekiq'].version)
+  Sidekiq::Web.configure do |config|
+    config.register_extension(Sidekiq::History::WebExtension,
+                              name: 'History',
+                              tab: 'History',
+                              index: 'history',
+                              root_dir: File.expand_path('../../web', __dir__))
+  end
 else
-  Sidekiq::Web.tabs['History'] = 'history'
+  Sidekiq::Web.register(Sidekiq::History::WebExtension)
+
+  if Sidekiq::Web.tabs.is_a?(Array)
+    # For Sidekiq < 2.5
+    Sidekiq::Web.tabs << 'history'
+  else
+    Sidekiq::Web.tabs['History'] = 'history'
+  end
 end

--- a/lib/sidekiq/history/web_extension.rb
+++ b/lib/sidekiq/history/web_extension.rb
@@ -31,7 +31,9 @@ module Sidekiq
           render(:erb, File.read("#{ROOT}/views/history.erb"))
         end
 
-        app.settings.locales << File.expand_path('locales', ROOT)
+        if Gem::Dependency.new('', '< 8.0.0').match?('', Gem.loaded_specs['sidekiq'].version)
+          app.settings.locales << File.expand_path('locales', ROOT)
+        end
       end
     end
   end

--- a/lib/sidekiq/history/web_extension.rb
+++ b/lib/sidekiq/history/web_extension.rb
@@ -3,31 +3,51 @@ module Sidekiq
     module WebExtension
       ROOT = File.expand_path('../../../web', __dir__)
 
+      # Helpers module provides utility methods for the Sidekiq History web extension.
+      module Helpers
+        # Fetches the query parameters or body from the request based on the Sidekiq version.
+        #
+        # Sidekiq 8.0 recommended `url_params` as a replacement for `params`.
+        # This method ensures compatibility with both older and newer versions of Sidekiq.
+        #
+        # @param key [String] The key to fetch from the request.
+        # @return [String, nil] The value associated with the key, or nil if not found.
+        def request_params(key)
+          if Gem::Dependency.new('', '>= 8.0.0').match?('', Gem.loaded_specs['sidekiq'].version)
+            url_params(key.to_s)
+          else
+            params[key]
+          end
+        end
+      end
+
       def self.registered(app)
+        app.helpers Helpers
+
         app.get '/history' do
-          @count = (params[:count] || 25).to_i
-          (@current_page, @total_size, @messages) = page('history', params[:page], @count, reverse: true)
+          @count = (request_params(:count) || 25).to_i
+          (@current_page, @total_size, @messages) = page('history', request_params(:page), @count, reverse: true)
           @messages = @messages.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
 
           render(:erb, File.read("#{ROOT}/views/history.erb"))
         end
 
         app.post '/history/remove' do
-          Sidekiq::History.reset_history(counter: params['counter'])
+          Sidekiq::History.reset_history(counter: request_params(:counter))
           redirect("#{root_path}history")
         end
 
         app.get '/filter/history' do
-          return redirect "#{root_path}history" unless params[:substr]
+          return redirect "#{root_path}history" unless request_params(:substr)
 
-          @messages = search(HistorySet.new, params[:substr])
+          @messages = search(HistorySet.new, request_params(:substr))
           render(:erb, File.read("#{ROOT}/views/history.erb"))
         end
 
         app.post '/filter/history' do
-          return redirect "#{root_path}history" unless params[:substr]
+          return redirect "#{root_path}history" unless request_params(:substr)
 
-          @messages = search(HistorySet.new, params[:substr])
+          @messages = search(HistorySet.new, request_params(:substr))
           render(:erb, File.read("#{ROOT}/views/history.erb"))
         end
 

--- a/sidekiq-history.gemspec
+++ b/sidekiq-history.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sidekiq", ">= 6.5.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "sprockets"


### PR DESCRIPTION
## What's Changes

* Enhance compatibility with Sidekiq 8 by adjusting web configuration and parameter handling.
    * The configuration method for `Sidekiq::Web` has changed in Sidekiq 8.0 (see pull request: https://github.com/sidekiq/sidekiq/pull/6532).
    * Changed from getting parameters directly from `params` to getting them from the `url_params` method.
* Update development dependencies to require Bundler version 2.0 or higher.

## Testing

* Confirmed that the Web UI is displayed in the following environments:
    * Sidekiq 8.0.3, Ruby 3.4.3
        * ![image](https://github.com/user-attachments/assets/03098208-0f40-439c-93f8-f175d22bdd31)
    * Sidekiq 7.3.9, Ruby 3.4.3
      * ![image](https://github.com/user-attachments/assets/ecef0742-efd1-47ed-a51c-4225daa75748)

The following files were used for verification

Gemfile
```rb
source 'https://rubygems.org'

# Specify your gem's dependencies in sidekiq-history.gemspec
gemspec

gem 'sidekiq', '~> 8.0'
gem 'rackup'
gem 'webrick'
```

`config.ru`
```rb
require "securerandom"
require "rack/session"
require "sidekiq/web"

$LOAD_PATH.unshift(File.expand_path('lib', __dir__))
require 'sidekiq/history'

# In a multi-process deployment, all Web UI instances should share
# this secret key so they can all decode the encrypted browser cookies
# and provide a working session.
# Rails does this in /config/initializers/secret_token.rb
secret_key = SecureRandom.hex(32)
use Rack::Session::Cookie, secret: secret_key, same_site: true, max_age: 86400
run Sidekiq::Web
```

`lib/sidekiq/history/demo_job.rb` (for test job)

```rb
require 'sidekiq'

$LOAD_PATH.unshift(File.expand_path('../../../lib', __dir__))
require 'sidekiq/history'

module Sidekiq
  module History
    class DemoJob
      include Sidekiq::Job

      def perform(*args)
        puts "DemoJob is running with arguments: #{args}"
        sleep(2)
      end
    end
  end
end
```
